### PR TITLE
Please use an actual status page

### DIFF
--- a/psgallery_status.md
+++ b/psgallery_status.md
@@ -1,6 +1,6 @@
 
-PowerShell Gallery Status
-=========================
+PowerShell Gallery Status 
+==========================
 ### The [PowerShell Gallery](https://powershellgallery.com) is currently:  __Operating with Statistic Errors__
 
 ### 10/15/2020 - PowerShellGallery.com may temporarily experience latency and/or low availability 


### PR DESCRIPTION
Considering how important this resource is to the community as a whole I think it deserves a better status indicator than an .md file. There have been a number of service interruptions recently. Every time it happens our AZSK tasks fail, causing deployments to fail. There is rarely a prompt indication from the official service that there is even an issue. I'm forced to use sketchy 3rd party reporting services like:

https://isitdownorjust.me/powershellgallery-com/

